### PR TITLE
[codex] Adopt Proton shared processor helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,6 @@ Prerequisites: JDK 17+, Ruby 2.7.x with Bundler, Node.js (for docs site) and Yar
 
 ## Coding Style & Naming Conventions
 
-- Language: Java 17; compilation uses `-Xlint:all` and `-Werror` (warnings must be fixed).
-- Indentation: 2 spaces; braces on a new line for types/methods; keep imports ordered and minimal.
 - Annotations: processor internals use JSpecify (`@NullMarked` packages and `@Nullable` only where needed);
   generated code, public examples, and annotation-processor input fixtures may still use `javax.annotation`.
   Use `final` where practical.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,12 +2,6 @@
 
 This guide helps contributors work effectively on the Sting codebase.
 
-## User Interaction
-
-When asked to perform a task, ask the user questions one at a time until you have enough context. Feel free to make
-reasonable assumptions based on patterns present in the code and ask the user to confirm the assumptions if there are
-reasonable alternatives.
-
 ## Project Structure & Module Organization
 
 - Java modules: `core/` (runtime/annotations), `processor/` (annotation processor).

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -607,30 +607,30 @@ _http_file(
 
 _http_file(
     name = "proton_core",
-    downloaded_file_path = "org/realityforge/proton/proton-core/0.73-SNAPSHOT/proton-core-0.73-SNAPSHOT.jar",
-    sha256 = "2c134f48590f48d72e40a967247b39348b0b296f7d153ed5eee0f72da975cd5a",
-    urls = ["file:///Users/peter/.m2/repository/org/realityforge/proton/proton-core/0.73-SNAPSHOT/proton-core-0.73-SNAPSHOT.jar"],
+    downloaded_file_path = "org/realityforge/proton/proton-core/0.74/proton-core-0.74.jar",
+    sha256 = "45d18db460b24e37bd37a25c4680c3f45d77a7f05ae0153d524a2f5f4cd2e72d",
+    urls = ["https://repo.maven.apache.org/maven2/org/realityforge/proton/proton-core/0.74/proton-core-0.74.jar"],
 )
 
 _http_file(
     name = "proton_core__sources",
-    downloaded_file_path = "org/realityforge/proton/proton-core/0.73-SNAPSHOT/proton-core-0.73-SNAPSHOT-sources.jar",
-    sha256 = "6c040682231c8ad640b78ee8901ee993bd73986ace69cb2a6cb1225896d67386",
-    urls = ["file:///Users/peter/.m2/repository/org/realityforge/proton/proton-core/0.73-SNAPSHOT/proton-core-0.73-SNAPSHOT-sources.jar"],
+    downloaded_file_path = "org/realityforge/proton/proton-core/0.74/proton-core-0.74-sources.jar",
+    sha256 = "7cb00ca7dc2485a254b01da9c6cd479d84f648786be54d31423797722c6a0cdc",
+    urls = ["https://repo.maven.apache.org/maven2/org/realityforge/proton/proton-core/0.74/proton-core-0.74-sources.jar"],
 )
 
 _http_file(
     name = "proton_qa",
-    downloaded_file_path = "org/realityforge/proton/proton-qa/0.73-SNAPSHOT/proton-qa-0.73-SNAPSHOT.jar",
-    sha256 = "abd8319119e764770c89db30acf3a425e644688f3f5881ee783e1a7651e4bca6",
-    urls = ["file:///Users/peter/.m2/repository/org/realityforge/proton/proton-qa/0.73-SNAPSHOT/proton-qa-0.73-SNAPSHOT.jar"],
+    downloaded_file_path = "org/realityforge/proton/proton-qa/0.74/proton-qa-0.74.jar",
+    sha256 = "a004182042e8f395ab26fb3056c6761e0814ee3a4f05aa6afe84d128b927b883",
+    urls = ["https://repo.maven.apache.org/maven2/org/realityforge/proton/proton-qa/0.74/proton-qa-0.74.jar"],
 )
 
 _http_file(
     name = "proton_qa__sources",
-    downloaded_file_path = "org/realityforge/proton/proton-qa/0.73-SNAPSHOT/proton-qa-0.73-SNAPSHOT-sources.jar",
-    sha256 = "99a9253349f938cd1e664dda9260e3c24b5bf1d2218dedc6ef91b59902a5b677",
-    urls = ["file:///Users/peter/.m2/repository/org/realityforge/proton/proton-qa/0.73-SNAPSHOT/proton-qa-0.73-SNAPSHOT-sources.jar"],
+    downloaded_file_path = "org/realityforge/proton/proton-qa/0.74/proton-qa-0.74-sources.jar",
+    sha256 = "d4cfaa74bd03393b3c6ecc738a23309db36d71fe99839fb522413b9b4cdc95e3",
+    urls = ["https://repo.maven.apache.org/maven2/org/realityforge/proton/proton-qa/0.74/proton-qa-0.74-sources.jar"],
 )
 
 _http_file(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -607,30 +607,30 @@ _http_file(
 
 _http_file(
     name = "proton_core",
-    downloaded_file_path = "org/realityforge/proton/proton-core/0.72/proton-core-0.72.jar",
-    sha256 = "173387044c98b8eb7a10789bcec9d11bd2858c3f7bf73fd587de97b830edab38",
-    urls = ["https://repo.maven.apache.org/maven2/org/realityforge/proton/proton-core/0.72/proton-core-0.72.jar"],
+    downloaded_file_path = "org/realityforge/proton/proton-core/0.73-SNAPSHOT/proton-core-0.73-SNAPSHOT.jar",
+    sha256 = "2c134f48590f48d72e40a967247b39348b0b296f7d153ed5eee0f72da975cd5a",
+    urls = ["file:///Users/peter/.m2/repository/org/realityforge/proton/proton-core/0.73-SNAPSHOT/proton-core-0.73-SNAPSHOT.jar"],
 )
 
 _http_file(
     name = "proton_core__sources",
-    downloaded_file_path = "org/realityforge/proton/proton-core/0.72/proton-core-0.72-sources.jar",
-    sha256 = "aaf6ecff25e47189202e05793eaea6957a38e6ca74b031a1b2da6f48b1eb0861",
-    urls = ["https://repo.maven.apache.org/maven2/org/realityforge/proton/proton-core/0.72/proton-core-0.72-sources.jar"],
+    downloaded_file_path = "org/realityforge/proton/proton-core/0.73-SNAPSHOT/proton-core-0.73-SNAPSHOT-sources.jar",
+    sha256 = "6c040682231c8ad640b78ee8901ee993bd73986ace69cb2a6cb1225896d67386",
+    urls = ["file:///Users/peter/.m2/repository/org/realityforge/proton/proton-core/0.73-SNAPSHOT/proton-core-0.73-SNAPSHOT-sources.jar"],
 )
 
 _http_file(
     name = "proton_qa",
-    downloaded_file_path = "org/realityforge/proton/proton-qa/0.72/proton-qa-0.72.jar",
-    sha256 = "75de7e6cc73b029e1a221305fdd1e7d8050acff76ba7b1f5166ae15c859e3320",
-    urls = ["https://repo.maven.apache.org/maven2/org/realityforge/proton/proton-qa/0.72/proton-qa-0.72.jar"],
+    downloaded_file_path = "org/realityforge/proton/proton-qa/0.73-SNAPSHOT/proton-qa-0.73-SNAPSHOT.jar",
+    sha256 = "abd8319119e764770c89db30acf3a425e644688f3f5881ee783e1a7651e4bca6",
+    urls = ["file:///Users/peter/.m2/repository/org/realityforge/proton/proton-qa/0.73-SNAPSHOT/proton-qa-0.73-SNAPSHOT.jar"],
 )
 
 _http_file(
     name = "proton_qa__sources",
-    downloaded_file_path = "org/realityforge/proton/proton-qa/0.72/proton-qa-0.72-sources.jar",
-    sha256 = "944e4a391a7acf14c33a5c8be2dea0117448502e6c8c9c29c0b52da5a197ab70",
-    urls = ["https://repo.maven.apache.org/maven2/org/realityforge/proton/proton-qa/0.72/proton-qa-0.72-sources.jar"],
+    downloaded_file_path = "org/realityforge/proton/proton-qa/0.73-SNAPSHOT/proton-qa-0.73-SNAPSHOT-sources.jar",
+    sha256 = "99a9253349f938cd1e664dda9260e3c24b5bf1d2218dedc6ef91b59902a5b677",
+    urls = ["file:///Users/peter/.m2/repository/org/realityforge/proton/proton-qa/0.73-SNAPSHOT/proton-qa-0.73-SNAPSHOT-sources.jar"],
 )
 
 _http_file(

--- a/build.yaml
+++ b/build.yaml
@@ -10,8 +10,8 @@ artifacts:
 
   javapoet: com.palantir.javapoet:javapoet:jar:0.14.0
 
-  proton_core: org.realityforge.proton:proton-core:jar:0.73-SNAPSHOT
-  proton_qa: org.realityforge.proton:proton-qa:jar:0.73-SNAPSHOT
+  proton_core: org.realityforge.proton:proton-core:jar:0.74
+  proton_qa: org.realityforge.proton:proton-qa:jar:0.74
 
   guava: com.google.guava:guava:jar:27.1-jre
   guava_failureaccess: com.google.guava:failureaccess:jar:1.0.1

--- a/build.yaml
+++ b/build.yaml
@@ -10,8 +10,8 @@ artifacts:
 
   javapoet: com.palantir.javapoet:javapoet:jar:0.14.0
 
-  proton_core: org.realityforge.proton:proton-core:jar:0.72
-  proton_qa: org.realityforge.proton:proton-qa:jar:0.72
+  proton_core: org.realityforge.proton:proton-core:jar:0.73-SNAPSHOT
+  proton_qa: org.realityforge.proton:proton-qa:jar:0.73-SNAPSHOT
 
   guava: com.google.guava:guava:jar:27.1-jre
   guava_failureaccess: com.google.guava:failureaccess:jar:1.0.1

--- a/docs/processor_options.md
+++ b/docs/processor_options.md
@@ -35,7 +35,8 @@ the options supported by the annotation processor.
     <td>sting.format_generated_source</td>
     <td>
     A flag that will format Sting generated Java source before writing it if set to <code>true</code>. Formatting
-    is disabled by default and requires additional JDK exports on JDK 16 and later. See
+    is enabled by default and requires additional JDK exports on JDK 16 and later. Set this to <code>false</code> to
+    disable generated source formatting. See
     <a href="project_setup.html">Project Setup</a> for further details.
     </td>
   </tr>

--- a/docs/project_setup.md
+++ b/docs/project_setup.md
@@ -62,13 +62,12 @@ compiler plugin from within the `pom.xml`:
 
 ### Optional Generated Source Formatting
 
-By default, the Sting processor writes the standard JavaPoet generated source. To format generated
-Sting source, pass the literal annotation processor option `-Asting.format_generated_source=true`.
-Any other value, or omitting the option, leaves generated source unformatted.
+By default, the Sting processor formats generated Java source before writing it. To disable generated
+source formatting, pass the literal annotation processor option `-Asting.format_generated_source=false`.
 
 The formatter support is supplied by Proton and shaded inside the `sting-processor` artifact, but the
 formatter uses JDK compiler internals. On JDK 16 and later, the JVM running `javac` and annotation
-processing must receive these exports when formatting is enabled:
+processing must receive these exports unless generated source formatting is disabled:
 
 ```text
 --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED

--- a/processor/src/main/java/sting/processor/Binding.java
+++ b/processor/src/main/java/sting/processor/Binding.java
@@ -11,6 +11,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import org.jspecify.annotations.Nullable;
+import org.realityforge.proton.ElementsUtil;
 
 final class Binding {
     /**
@@ -210,13 +211,10 @@ final class Binding {
             final var input = (InputDescriptor) getOwner();
             return ((TypeElement) _element).getQualifiedName() + "." + input.name() + "/" + input.service();
         } else if (Kind.INJECTABLE == _kind) {
-            return ((TypeElement) Objects.requireNonNull(_element.getEnclosingElement()))
-                    .getQualifiedName()
-                    .toString();
+            return ElementsUtil.getOwningType(_element).getQualifiedName().toString();
         } else {
             assert Kind.PROVIDES == _kind;
-            return ((TypeElement) Objects.requireNonNull(_element.getEnclosingElement())).getQualifiedName() + "."
-                    + _element.getSimpleName();
+            return ElementsUtil.getOwningType(_element).getQualifiedName() + "." + _element.getSimpleName();
         }
     }
 

--- a/processor/src/main/java/sting/processor/InjectableDescriptor.java
+++ b/processor/src/main/java/sting/processor/InjectableDescriptor.java
@@ -3,6 +3,7 @@ package sting.processor;
 import java.util.Objects;
 import javax.json.stream.JsonGenerator;
 import javax.lang.model.element.TypeElement;
+import org.realityforge.proton.ElementsUtil;
 
 final class InjectableDescriptor {
     private final Binding _binding;
@@ -27,7 +28,7 @@ final class InjectableDescriptor {
     }
 
     TypeElement getElement() {
-        return (TypeElement) Objects.requireNonNull(_binding.getElement().getEnclosingElement());
+        return ElementsUtil.getOwningType(_binding.getElement());
     }
 
     Binding getBinding() {

--- a/processor/src/main/java/sting/processor/InterceptorProxyGenerator.java
+++ b/processor/src/main/java/sting/processor/InterceptorProxyGenerator.java
@@ -162,7 +162,7 @@ final class InterceptorProxyGenerator {
     private static boolean shouldProxyMethod(final TypeElement serviceElement, final ExecutableElement method) {
         final var modifiers = method.getModifiers();
         if (!modifiers.contains(Modifier.STATIC) && !modifiers.contains(Modifier.PRIVATE)) {
-            final var element = (TypeElement) Objects.requireNonNull(method.getEnclosingElement());
+            final var element = ElementsUtil.getOwningType(method);
             return !Object.class.getName().equals(element.getQualifiedName().toString()) || element == serviceElement;
         } else {
             return false;

--- a/processor/src/main/java/sting/processor/StingProcessor.java
+++ b/processor/src/main/java/sting/processor/StingProcessor.java
@@ -50,10 +50,12 @@ import org.realityforge.proton.ElementsUtil;
 import org.realityforge.proton.GeneratorUtil;
 import org.realityforge.proton.JsonUtil;
 import org.realityforge.proton.MemberChecks;
+import org.realityforge.proton.NamesUtil;
 import org.realityforge.proton.ProcessorException;
 import org.realityforge.proton.ResourceUtil;
 import org.realityforge.proton.StopWatch;
 import org.realityforge.proton.SuperficialValidation;
+import org.realityforge.proton.SuppressWarningsUtil;
 import org.realityforge.proton.TypesUtil;
 
 /**
@@ -952,7 +954,7 @@ public final class StingProcessor extends AbstractStandardProcessor {
             if (!include.auto()
                     && !injectable.getBinding().isEager()
                     && injectable.isAutoDiscoverable()
-                    && ElementsUtil.isWarningNotSuppressed(originator, Constants.WARNING_AUTO_DISCOVERABLE_INCLUDED)) {
+                    && SuppressWarningsUtil.isNotSuppressed(originator, Constants.WARNING_AUTO_DISCOVERABLE_INCLUDED)) {
                 final String message = MemberChecks.shouldNot(
                         annotationClassname,
                         "include an auto-discoverable type " + classname + ". "
@@ -965,11 +967,7 @@ public final class StingProcessor extends AbstractStandardProcessor {
 
     private void processInjectorFragment(final TypeElement element) {
         debug(() -> "Processing Injector Fragment: " + element);
-        final ElementKind kind = element.getKind();
-        if (ElementKind.INTERFACE != kind) {
-            throw new ProcessorException(
-                    MemberChecks.must(Constants.INJECTOR_FRAGMENT_CLASSNAME, "be an interface"), element);
-        }
+        MemberChecks.mustBeInterface(Constants.INJECTOR_FRAGMENT_CLASSNAME, element);
         final var methods =
                 ElementsUtil.getMethods(element, processingEnv.getElementUtils(), processingEnv.getTypeUtils());
         for (final ExecutableElement method : methods) {
@@ -989,14 +987,8 @@ public final class StingProcessor extends AbstractStandardProcessor {
 
     private void processInjector(final TypeElement element) throws Exception {
         debug(() -> "Processing Injector: " + element);
-        final ElementKind kind = element.getKind();
-        if (ElementKind.INTERFACE != kind) {
-            throw new ProcessorException(MemberChecks.must(Constants.INJECTOR_CLASSNAME, "be an interface"), element);
-        }
-        if (!element.getTypeParameters().isEmpty()) {
-            throw new ProcessorException(
-                    MemberChecks.mustNot(Constants.INJECTOR_CLASSNAME, "have type parameters"), element);
-        }
+        MemberChecks.mustBeInterface(Constants.INJECTOR_CLASSNAME, element);
+        MemberChecks.mustNotHaveTypeParameters(Constants.INJECTOR_CLASSNAME, element);
         final List<? extends AnnotationMirror> scopedAnnotations = getScopedAnnotations(element);
         if (!scopedAnnotations.isEmpty()) {
             throw new ProcessorException(
@@ -1446,12 +1438,9 @@ public final class StingProcessor extends AbstractStandardProcessor {
 
     private void processFragment(final TypeElement element) {
         debug(() -> "Processing Fragment: " + element);
-        if (ElementKind.INTERFACE != element.getKind()) {
-            throw new ProcessorException(MemberChecks.must(Constants.FRAGMENT_CLASSNAME, "be an interface"), element);
-        } else if (!element.getTypeParameters().isEmpty()) {
-            throw new ProcessorException(
-                    MemberChecks.mustNot(Constants.FRAGMENT_CLASSNAME, "have type parameters"), element);
-        } else if (!element.getInterfaces().isEmpty()) {
+        MemberChecks.mustBeInterface(Constants.FRAGMENT_CLASSNAME, element);
+        MemberChecks.mustNotHaveTypeParameters(Constants.FRAGMENT_CLASSNAME, element);
+        if (!element.getInterfaces().isEmpty()) {
             throw new ProcessorException(
                     MemberChecks.mustNot(Constants.FRAGMENT_CLASSNAME, "extend any interfaces"), element);
         }
@@ -1490,12 +1479,9 @@ public final class StingProcessor extends AbstractStandardProcessor {
 
     private void processFactory(final TypeElement element) {
         debug(() -> "Processing Factory: " + element);
-        if (ElementKind.INTERFACE != element.getKind()) {
-            throw new ProcessorException(MemberChecks.must(Constants.FACTORY_CLASSNAME, "be an interface"), element);
-        } else if (!element.getTypeParameters().isEmpty()) {
-            throw new ProcessorException(
-                    MemberChecks.mustNot(Constants.FACTORY_CLASSNAME, "have type parameters"), element);
-        } else if (!element.getInterfaces().isEmpty()) {
+        MemberChecks.mustBeInterface(Constants.FACTORY_CLASSNAME, element);
+        MemberChecks.mustNotHaveTypeParameters(Constants.FACTORY_CLASSNAME, element);
+        if (!element.getInterfaces().isEmpty()) {
             throw new ProcessorException(
                     MemberChecks.mustNot(Constants.FACTORY_CLASSNAME, "extend any interfaces"), element);
         }
@@ -2218,7 +2204,7 @@ public final class StingProcessor extends AbstractStandardProcessor {
                 if (name.isEmpty()) {
                     throw new ProcessorException(
                             "implementedBy template contains an empty placeholder", element, annotation);
-                } else if (!SourceVersion.isIdentifier(name) || SourceVersion.isKeyword(name)) {
+                } else if (!NamesUtil.isJavaIdentifier(name)) {
                     throw new ProcessorException(
                             "implementedBy template placeholder {" + name + "} must be a Java identifier",
                             element,
@@ -2660,11 +2646,8 @@ public final class StingProcessor extends AbstractStandardProcessor {
     }
 
     private boolean isUncheckedThrowable(final TypeMirror type) {
-        final var elementUtils = processingEnv.getElementUtils();
-        final var runtimeException = elementUtils.getTypeElement(RuntimeException.class.getName());
-        final var error = elementUtils.getTypeElement(Error.class.getName());
-        final var typeUtils = processingEnv.getTypeUtils();
-        return typeUtils.isAssignable(type, runtimeException.asType()) || typeUtils.isAssignable(type, error.asType());
+        return ElementsUtil.isAssignableTo(processingEnv, type, RuntimeException.class.getName())
+                || ElementsUtil.isAssignableTo(processingEnv, type, Error.class.getName());
     }
 
     private void validateNoInheritedLifecycleMethods(final TypeElement element) {
@@ -2894,7 +2877,7 @@ public final class StingProcessor extends AbstractStandardProcessor {
             return false;
         } else {
             for (final var part : name.split("\\.")) {
-                if (part.isEmpty() || !SourceVersion.isIdentifier(part) || SourceVersion.isKeyword(part)) {
+                if (!NamesUtil.isJavaIdentifier(part)) {
                     return false;
                 }
             }
@@ -2966,17 +2949,12 @@ public final class StingProcessor extends AbstractStandardProcessor {
 
     private void processInjectable(final TypeElement element) {
         debug(() -> "Processing Injectable: " + element);
-        if (ElementKind.CLASS != element.getKind()) {
-            throw new ProcessorException(MemberChecks.must(Constants.INJECTABLE_CLASSNAME, "be a class"), element);
-        } else if (element.getModifiers().contains(Modifier.ABSTRACT)) {
+        MemberChecks.mustBeClass(Constants.INJECTABLE_CLASSNAME, element);
+        if (element.getModifiers().contains(Modifier.ABSTRACT)) {
             throw new ProcessorException(MemberChecks.mustNot(Constants.INJECTABLE_CLASSNAME, "be abstract"), element);
-        } else if (ElementsUtil.isNonStaticNestedClass(element)) {
-            throw new ProcessorException(
-                    MemberChecks.mustNot(Constants.INJECTABLE_CLASSNAME, "be a non-static nested class"), element);
-        } else if (!element.getTypeParameters().isEmpty()) {
-            throw new ProcessorException(
-                    MemberChecks.mustNot(Constants.INJECTABLE_CLASSNAME, "have type parameters"), element);
         }
+        MemberChecks.mustNotBeNonStaticNestedType(Constants.INJECTABLE_CLASSNAME, element);
+        MemberChecks.mustNotHaveTypeParameters(Constants.INJECTABLE_CLASSNAME, element);
         final List<ExecutableElement> constructors = ElementsUtil.getConstructors(element);
         final ExecutableElement constructor = constructors.get(0);
         if (constructors.size() > 1) {
@@ -3002,7 +2980,7 @@ public final class StingProcessor extends AbstractStandardProcessor {
 
         final String qualifier = getQualifier(element);
         if (AnnotationsUtil.hasAnnotationOfType(element, Constants.JSR_330_NAMED_CLASSNAME)
-                && ElementsUtil.isWarningNotSuppressed(element, Constants.WARNING_JSR_330_NAMED)) {
+                && SuppressWarningsUtil.isNotSuppressed(element, Constants.WARNING_JSR_330_NAMED)) {
             final String message = MemberChecks.mustNot(
                     Constants.INJECTABLE_CLASSNAME,
                     "be annotated with the " + Constants.JSR_330_NAMED_CLASSNAME + " annotation. " + "Use the "
@@ -3011,7 +2989,7 @@ public final class StingProcessor extends AbstractStandardProcessor {
             warning(message, element);
         }
         if (AnnotationsUtil.hasAnnotationOfType(element, Constants.CDI_TYPED_CLASSNAME)
-                && ElementsUtil.isWarningNotSuppressed(element, Constants.WARNING_CDI_TYPED)) {
+                && SuppressWarningsUtil.isNotSuppressed(element, Constants.WARNING_CDI_TYPED)) {
             final String message = MemberChecks.mustNot(
                     Constants.INJECTABLE_CLASSNAME,
                     "be annotated with the " + Constants.CDI_TYPED_CLASSNAME + " annotation. " + "Use the "
@@ -3020,7 +2998,7 @@ public final class StingProcessor extends AbstractStandardProcessor {
             warning(message, element);
         }
         if (AnnotationsUtil.hasAnnotationOfType(constructor, Constants.JSR_330_INJECT_CLASSNAME)
-                && ElementsUtil.isWarningNotSuppressed(constructor, Constants.WARNING_JSR_330_INJECT)) {
+                && SuppressWarningsUtil.isNotSuppressed(constructor, Constants.WARNING_JSR_330_INJECT)) {
             final String message = MemberChecks.mustNot(
                     Constants.INJECTABLE_CLASSNAME,
                     "be annotated with the " + Constants.JSR_330_INJECT_CLASSNAME + " annotation. "
@@ -3131,7 +3109,7 @@ public final class StingProcessor extends AbstractStandardProcessor {
                     MemberChecks.mustNot(
                             Constants.FACTORY_CLASSNAME, "contain abstract methods that return an abstract class"),
                     method);
-        } else if (ElementsUtil.isNonStaticNestedClass(producedType)) {
+        } else if (ElementsUtil.isNonStaticNestedType(producedType)) {
             throw new ProcessorException(
                     MemberChecks.mustNot(
                             Constants.FACTORY_CLASSNAME,
@@ -3152,7 +3130,7 @@ public final class StingProcessor extends AbstractStandardProcessor {
                     method);
         }
         final ExecutableElement constructor = constructors.get(0);
-        if (!isFactoryAccessible(factory, constructor)) {
+        if (!ElementsUtil.isElementAccessibleFrom(factory, constructor)) {
             throw new ProcessorException(
                     MemberChecks.must(
                             Constants.FACTORY_CLASSNAME,
@@ -3251,20 +3229,6 @@ public final class StingProcessor extends AbstractStandardProcessor {
         return candidate;
     }
 
-    private boolean isFactoryAccessible(final TypeElement factory, final ExecutableElement constructor) {
-        final Set<Modifier> modifiers = constructor.getModifiers();
-        if (modifiers.contains(Modifier.PRIVATE)) {
-            return false;
-        } else if (modifiers.contains(Modifier.PUBLIC)) {
-            return true;
-        } else {
-            final String factoryPackage = GeneratorUtil.getQualifiedPackageName(factory);
-            final var targetPackage =
-                    GeneratorUtil.getQualifiedPackageName((TypeElement) constructor.getEnclosingElement());
-            return factoryPackage.equals(targetPackage);
-        }
-    }
-
     // Binary descriptor writing and verification removed
 
     private void emitInjectableJsonDescriptor(final InjectableDescriptor injectable) throws IOException {
@@ -3330,7 +3294,7 @@ public final class StingProcessor extends AbstractStandardProcessor {
                 }
                 final String qualifier = getQualifier(parameter);
                 if (AnnotationsUtil.hasAnnotationOfType(parameter, Constants.JSR_330_NAMED_CLASSNAME)
-                        && ElementsUtil.isWarningNotSuppressed(parameter, Constants.WARNING_JSR_330_NAMED)) {
+                        && SuppressWarningsUtil.isNotSuppressed(parameter, Constants.WARNING_JSR_330_NAMED)) {
                     final String message = MemberChecks.mustNot(
                             Constants.INJECTABLE_CLASSNAME,
                             "contain a constructor with a parameter annotated with the "
@@ -3355,7 +3319,7 @@ public final class StingProcessor extends AbstractStandardProcessor {
     private void injectableShouldNotHaveScopedAnnotation(final TypeElement element) {
         final List<? extends AnnotationMirror> scopedAnnotations = getScopedAnnotations(element);
         if (!scopedAnnotations.isEmpty()
-                && ElementsUtil.isWarningNotSuppressed(element, Constants.WARNING_JSR_330_SCOPED)) {
+                && SuppressWarningsUtil.isNotSuppressed(element, Constants.WARNING_JSR_330_SCOPED)) {
             final String message = MemberChecks.shouldNot(
                     Constants.INJECTABLE_CLASSNAME,
                     "be annotated with an annotation that is annotated with the " + Constants.JSR_330_SCOPE_CLASSNAME
@@ -3368,7 +3332,7 @@ public final class StingProcessor extends AbstractStandardProcessor {
     private void injectableConstructorShouldNotBePublic(final ExecutableElement constructor) {
         if (Elements.Origin.EXPLICIT == processingEnv.getElementUtils().getOrigin(constructor)
                 && constructor.getModifiers().contains(Modifier.PUBLIC)
-                && ElementsUtil.isWarningNotSuppressed(constructor, Constants.WARNING_PUBLIC_CONSTRUCTOR)) {
+                && SuppressWarningsUtil.isNotSuppressed(constructor, Constants.WARNING_PUBLIC_CONSTRUCTOR)) {
             final String message = MemberChecks.shouldNot(
                     Constants.INJECTABLE_CLASSNAME,
                     "have a public constructor. The type is instantiated by the injector "
@@ -3380,7 +3344,7 @@ public final class StingProcessor extends AbstractStandardProcessor {
 
     private void injectableConstructorShouldNotBeProtected(final ExecutableElement constructor) {
         if (constructor.getModifiers().contains(Modifier.PROTECTED)
-                && ElementsUtil.isWarningNotSuppressed(constructor, Constants.WARNING_PROTECTED_CONSTRUCTOR)) {
+                && SuppressWarningsUtil.isNotSuppressed(constructor, Constants.WARNING_PROTECTED_CONSTRUCTOR)) {
             final String message = MemberChecks.shouldNot(
                     Constants.INJECTABLE_CLASSNAME,
                     "have a protected constructor. The type is instantiated by the "
@@ -3455,7 +3419,7 @@ public final class StingProcessor extends AbstractStandardProcessor {
         }
 
         if (element.getModifiers().contains(Modifier.ABSTRACT)
-                || ElementsUtil.isNonStaticNestedClass(element)
+                || ElementsUtil.isNonStaticNestedType(element)
                 || !element.getTypeParameters().isEmpty()) {
             // Invalid injectable; let normal processing flag this if encountered as source.
             return null;
@@ -3550,7 +3514,7 @@ public final class StingProcessor extends AbstractStandardProcessor {
             final TypeElement originator,
             final String annotationClassname,
             final Collection<IncludeDescriptor> includes) {
-        if (!ElementsUtil.isWarningNotSuppressed(originator, Constants.WARNING_REDUNDANT_DIRECT_INJECTABLE_INCLUDE)) {
+        if (SuppressWarningsUtil.isSuppressed(originator, Constants.WARNING_REDUNDANT_DIRECT_INJECTABLE_INCLUDE)) {
             return;
         }
 
@@ -3611,7 +3575,7 @@ public final class StingProcessor extends AbstractStandardProcessor {
 
     private void maybeWarnOnFragmentIncludeCycle(
             final TypeElement originator, final Collection<IncludeDescriptor> includes) {
-        if (!ElementsUtil.isWarningNotSuppressed(originator, Constants.WARNING_FRAGMENT_INCLUDE_CYCLE)) {
+        if (SuppressWarningsUtil.isSuppressed(originator, Constants.WARNING_FRAGMENT_INCLUDE_CYCLE)) {
             return;
         }
         final String originClassname = originator.getQualifiedName().toString();

--- a/third_party/java/BUILD.bazel
+++ b/third_party/java/BUILD.bazel
@@ -24,7 +24,7 @@ exports_files(["dependencies.yml"])
 # Dependency Graph Generated from the input data
 # +- org.realityforge.javax.annotation:javax.annotation:jar:1.1.1 [compile]
 # +- com.palantir.javapoet:javapoet:jar:0.14.0 [compile]
-# +- org.realityforge.proton:proton-core:jar:0.72 [compile]
+# +- org.realityforge.proton:proton-core:jar:0.73-SNAPSHOT [compile]
 # |  +- org.realityforge.javax.annotation:javax.annotation:jar:1.1.1 [compile]
 # |  +- org.glassfish:javax.json:jar:1.1 [compile]
 # |  +- com.palantir.javapoet:javapoet:jar:0.14.0 [compile]
@@ -36,10 +36,10 @@ exports_files(["dependencies.yml"])
 # |     +- com.google.errorprone:error_prone_annotations:jar:2.2.0 [compile] (conflicts with 2.49.0)
 # |     +- com.google.j2objc:j2objc-annotations:jar:1.1 [compile] (conflicts with 3.1)
 # |     \- org.codehaus.mojo:animal-sniffer-annotations:jar:1.17 [compile]
-# +- org.realityforge.proton:proton-qa:jar:0.72 [compile]
-# |  +- org.realityforge.proton:proton-core:jar:0.72 [compile]
-# |  +- org.realityforge.proton:proton-core:jar:sources:0.72 [compile]
-# |  +- org.realityforge.proton:proton-core:jar:javadoc:0.72 [compile]
+# +- org.realityforge.proton:proton-qa:jar:0.73-SNAPSHOT [compile]
+# |  +- org.realityforge.proton:proton-core:jar:0.73-SNAPSHOT [compile]
+# |  +- org.realityforge.proton:proton-core:jar:sources:0.73-SNAPSHOT [compile]
+# |  +- org.realityforge.proton:proton-core:jar:javadoc:0.73-SNAPSHOT [compile]
 # |  +- org.realityforge.javax.annotation:javax.annotation:jar:1.1.1 [compile]
 # |  +- org.glassfish:javax.json:jar:1.1 [compile]
 # |  +- com.palantir.javapoet:javapoet:jar:0.14.0 [compile]
@@ -482,7 +482,7 @@ _java_import(
     name = "proton_core",
     jars = ["@proton_core//file"],
     srcjar = "@proton_core__sources//file",
-    tags = ["maven_coordinates=org.realityforge.proton:proton-core:0.72"],
+    tags = ["maven_coordinates=org.realityforge.proton:proton-core:0.73-SNAPSHOT"],
     deps = [
         ":guava",
         ":javapoet",
@@ -495,7 +495,7 @@ _java_import(
     name = "proton_qa",
     jars = ["@proton_qa//file"],
     srcjar = "@proton_qa__sources//file",
-    tags = ["maven_coordinates=org.realityforge.proton:proton-qa:0.72"],
+    tags = ["maven_coordinates=org.realityforge.proton:proton-qa:0.73-SNAPSHOT"],
     deps = [
         ":error_prone_annotations",
         ":failureaccess",

--- a/third_party/java/BUILD.bazel
+++ b/third_party/java/BUILD.bazel
@@ -17,14 +17,14 @@ _java_plugin(
 # DO NOT EDIT: Content is auto-generated from //third_party/java:dependencies.yml by https://github.com/realityforge/bazel-depgen version 0.26
 
 # SHA256 of the configuration content that generated this content
-_CONFIG_SHA256 = "46FDB051DD06159E826D74533E20887F782236AA240E661B8AA201CB8D5B2905"
+_CONFIG_SHA256 = "ECA3D231F8807A73340B9F08AD256446BE8BF642FAF22738428BBB83623160DF"
 
 exports_files(["dependencies.yml"])
 
 # Dependency Graph Generated from the input data
 # +- org.realityforge.javax.annotation:javax.annotation:jar:1.1.1 [compile]
 # +- com.palantir.javapoet:javapoet:jar:0.14.0 [compile]
-# +- org.realityforge.proton:proton-core:jar:0.73-SNAPSHOT [compile]
+# +- org.realityforge.proton:proton-core:jar:0.74 [compile]
 # |  +- org.realityforge.javax.annotation:javax.annotation:jar:1.1.1 [compile]
 # |  +- org.glassfish:javax.json:jar:1.1 [compile]
 # |  +- com.palantir.javapoet:javapoet:jar:0.14.0 [compile]
@@ -36,10 +36,10 @@ exports_files(["dependencies.yml"])
 # |     +- com.google.errorprone:error_prone_annotations:jar:2.2.0 [compile] (conflicts with 2.49.0)
 # |     +- com.google.j2objc:j2objc-annotations:jar:1.1 [compile] (conflicts with 3.1)
 # |     \- org.codehaus.mojo:animal-sniffer-annotations:jar:1.17 [compile]
-# +- org.realityforge.proton:proton-qa:jar:0.73-SNAPSHOT [compile]
-# |  +- org.realityforge.proton:proton-core:jar:0.73-SNAPSHOT [compile]
-# |  +- org.realityforge.proton:proton-core:jar:sources:0.73-SNAPSHOT [compile]
-# |  +- org.realityforge.proton:proton-core:jar:javadoc:0.73-SNAPSHOT [compile]
+# +- org.realityforge.proton:proton-qa:jar:0.74 [compile]
+# |  +- org.realityforge.proton:proton-core:jar:0.74 [compile]
+# |  +- org.realityforge.proton:proton-core:jar:sources:0.74 [compile]
+# |  +- org.realityforge.proton:proton-core:jar:javadoc:0.74 [compile]
 # |  +- org.realityforge.javax.annotation:javax.annotation:jar:1.1.1 [compile]
 # |  +- org.glassfish:javax.json:jar:1.1 [compile]
 # |  +- com.palantir.javapoet:javapoet:jar:0.14.0 [compile]
@@ -482,7 +482,7 @@ _java_import(
     name = "proton_core",
     jars = ["@proton_core//file"],
     srcjar = "@proton_core__sources//file",
-    tags = ["maven_coordinates=org.realityforge.proton:proton-core:0.73-SNAPSHOT"],
+    tags = ["maven_coordinates=org.realityforge.proton:proton-core:0.74"],
     deps = [
         ":guava",
         ":javapoet",
@@ -495,7 +495,7 @@ _java_import(
     name = "proton_qa",
     jars = ["@proton_qa//file"],
     srcjar = "@proton_qa__sources//file",
-    tags = ["maven_coordinates=org.realityforge.proton:proton-qa:0.73-SNAPSHOT"],
+    tags = ["maven_coordinates=org.realityforge.proton:proton-qa:0.74"],
     deps = [
         ":error_prone_annotations",
         ":failureaccess",

--- a/third_party/java/dependencies.yml
+++ b/third_party/java/dependencies.yml
@@ -16,8 +16,8 @@ artifacts:
   - coord: com.palantir.javapoet:javapoet:0.14.0
     excludes:
       - com.palantir.javapoet:javapoet-root
-  - coord: org.realityforge.proton:proton-core:0.72
-  - coord: org.realityforge.proton:proton-qa:0.72
+  - coord: org.realityforge.proton:proton-core:0.73-SNAPSHOT
+  - coord: org.realityforge.proton:proton-qa:0.73-SNAPSHOT
   - coord: org.glassfish:javax.json:1.1
   # Processor tests need javaemul.internal.annotations.DoNotInline to exercise @Injector.gwt
   # AUTODETECT/ENABLE output without pulling the full GWT user jar into Bazel builds.

--- a/third_party/java/dependencies.yml
+++ b/third_party/java/dependencies.yml
@@ -16,8 +16,8 @@ artifacts:
   - coord: com.palantir.javapoet:javapoet:0.14.0
     excludes:
       - com.palantir.javapoet:javapoet-root
-  - coord: org.realityforge.proton:proton-core:0.73-SNAPSHOT
-  - coord: org.realityforge.proton:proton-qa:0.73-SNAPSHOT
+  - coord: org.realityforge.proton:proton-core:0.74
+  - coord: org.realityforge.proton:proton-qa:0.74
   - coord: org.glassfish:javax.json:1.1
   # Processor tests need javaemul.internal.annotations.DoNotInline to exercise @Injector.gwt
   # AUTODETECT/ENABLE output without pulling the full GWT user jar into Bazel builds.


### PR DESCRIPTION
## Summary
- Update Proton dependencies and generated Bazel metadata to the released `0.74` artifacts.
- Adopt shared Proton processor helpers across Sting processor code where behavior remains unchanged.
- Align processor option docs with the Proton generated-source formatting default.

## Validation
- `tools/update_java_deps.sh`
- `tools/java_format.sh write`
- `bundle exec buildr sting:processor:compile sting:processor:test`
- `bazel test //processor/src/test/java/sting/processor:all_tests`

Local run evidence:
- Dependency generation resolved `proton-core`/`proton-qa` `0.74` from Maven Central.
- Buildr `sting-processor`: 548/548, failures 0, skips 0.
- Bazel: 1 out of 1 test passed.
